### PR TITLE
Added a flag to disable REMOVE_TO_CONTINUE files

### DIFF
--- a/config.md
+++ b/config.md
@@ -86,6 +86,7 @@
     - **Items** _(integer)_
   - **`auto_mask`**: The auto mask configuration, the mask is used to mask the image on crop and skew calculation. Refer to _[#/definitions/auto_mask](#definitions/auto_mask)_.
   - **`auto_cut`**: The auto mask configuration, the mask is used to definitively mask the source image. Refer to _[#/definitions/auto_mask](#definitions/auto_mask)_.
+  - **`no_remove_to_continue`** _(boolean)_: Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf. Default: `false`.
   - **`deskew`** _(object)_: The deskew configuration.
     - **`min_angle`** _(number)_: The minimum angle to detect the image skew [degree]. Default: `-45`.
     - **`max_angle`** _(number)_: The maximum angle to detect the image skew [degree]. Default: `45`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -2814,4 +2814,4 @@ numpy = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "6c55fe45554dd5c8859e3c690ca10855ffa92a2a750a4ed047b2ed2f63143bb3"
+content-hash = "db57f15edbe5c1dc19d5abf40645a05a6d599a08fb983f3177b575c38c8dba80"

--- a/process.md
+++ b/process.md
@@ -100,6 +100,7 @@
     - **Items** _(integer)_
   - **`auto_mask`**: The auto mask configuration, the mask is used to mask the image on crop and skew calculation. Refer to _[#/definitions/auto_mask](#definitions/auto_mask)_.
   - **`auto_cut`**: The auto mask configuration, the mask is used to definitively mask the source image. Refer to _[#/definitions/auto_mask](#definitions/auto_mask)_.
+  - **`no_remove_to_continue`** _(boolean)_: Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf. Default: `false`.
   - **`deskew`** _(object)_: The deskew configuration.
     - **`min_angle`** _(number)_: The minimum angle to detect the image skew [degree]. Default: `-45`.
     - **`max_angle`** _(number)_: The maximum angle to detect the image skew [degree]. Default: `45`.

--- a/process.md
+++ b/process.md
@@ -132,4 +132,3 @@
     - **`graduation_text_font_color`** _(array)_: Default: `[0, 0, 0]`.
       - **Items** _(integer)_
     - **`graduation_text_margin`** _(integer)_: Default: `6`.
-  - **`no_remove_to_continue`** _(boolean)_: Do not wait for the deletion of REMOVE_TO_CONTINUE before submitting the processed file. Default: `false`.

--- a/process.md
+++ b/process.md
@@ -132,3 +132,4 @@
     - **`graduation_text_font_color`** _(array)_: Default: `[0, 0, 0]`.
       - **Items** _(integer)_
     - **`graduation_text_margin`** _(integer)_: Default: `6`.
+  - **`no_remove_to_continue`** _(boolean)_: Do not wait for the deletion of REMOVE_TO_CONTINUE before submitting the processed file. Default: `false`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ pyperclip = "1.8.2"
 tifffile = "2023.4.12"
 deepmerge = "1.1.0"
 matplotlib = "3.7.1"
+typing-extensions = "4.5.0"
 
 [tool.poetry.dev-dependencies]
 prospector = { version = "1.9.0", extras = ["with_bandit", "with_mypy", "with_pyroma"] }

--- a/scan_to_paperless/config.py
+++ b/scan_to_paperless/config.py
@@ -401,6 +401,15 @@ class Arguments(TypedDict, total=False):
 
     auto_mask: "AutoMask"
     auto_cut: "AutoMask"
+    no_remove_to_continue: bool
+    """
+    No REMOVE_TO_CONTINUE.
+
+    Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf.
+
+    default: False
+    """
+
     deskew: "_ArgumentsDeskew"
     line_detection: "LineDetection"
     rule: "Rule"
@@ -908,6 +917,10 @@ NO_AUTO_ROTATE_DEFAULT = False
 
 NO_CROP_DEFAULT = False
 """ Default value of the field path 'Arguments no_crop' """
+
+
+NO_REMOVE_TO_CONTINUE_DEFAULT = False
+""" Default value of the field path 'Arguments no_remove_to_continue' """
 
 
 PNGQUANT_OPTIONS_DEFAULT = ["--force", "--speed=1", "--strip", "--quality=0-32"]

--- a/scan_to_paperless/config_schema.json
+++ b/scan_to_paperless/config_schema.json
@@ -334,6 +334,12 @@
           "description": "The auto mask configuration, the mask is used to definitively mask the source image",
           "$ref": "#/definitions/auto_mask"
         },
+        "no_remove_to_continue": {
+          "type": "boolean",
+          "default": false,
+          "description": "Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf.",
+          "title": "No REMOVE_TO_CONTINUE"
+        },
         "deskew": {
           "type": "object",
           "description": "The deskew configuration",

--- a/scan_to_paperless/process.py
+++ b/scan_to_paperless/process.py
@@ -1666,7 +1666,7 @@ def _process(config_file_name: str, dirty: bool = False, print_waiting: bool = T
     try:
         rerun = False
         disable_remove_to_continue = config["args"].setdefault(
-            "no_remove_to_continue", schema.DISABLE_REMOVE_TO_CONTINUE_DEFAULT
+            "no_remove_to_continue", schema.NO_REMOVE_TO_CONTINUE_DEFAULT
         )
         if "steps" not in config:
             rerun = True

--- a/scan_to_paperless/process.py
+++ b/scan_to_paperless/process.py
@@ -1665,6 +1665,9 @@ def _process(config_file_name: str, dirty: bool = False, print_waiting: bool = T
 
     try:
         rerun = False
+        disable_remove_to_continue = config["args"].setdefault(
+            "no_remove_to_continue", schema.DISABLE_REMOVE_TO_CONTINUE_DEFAULT
+        )
         if "steps" not in config:
             rerun = True
         while config.get("steps") and not is_sources_present(config["steps"][-1]["sources"], root_folder):
@@ -1686,7 +1689,7 @@ def _process(config_file_name: str, dirty: bool = False, print_waiting: bool = T
         step = config["steps"][-1]
 
         if is_sources_present(step["sources"], root_folder):
-            if config["args"]["no_remove_to_continue"] == True:
+            if not disable_remove_to_continue:
                 if os.path.exists(os.path.join(root_folder, "REMOVE_TO_CONTINUE")) and not rerun:
                     return dirty, print_waiting
             if os.path.exists(os.path.join(root_folder, "DONE")) and not rerun:
@@ -1718,7 +1721,7 @@ def _process(config_file_name: str, dirty: bool = False, print_waiting: bool = T
                 if done:
                     with open(os.path.join(root_folder, "DONE"), "w"):
                         pass
-                elif config["args"]["no_remove_to_continue"] == True:
+                elif not disable_remove_to_continue:
                     with open(os.path.join(root_folder, "REMOVE_TO_CONTINUE"), "w"):
                         pass
 

--- a/scan_to_paperless/process.py
+++ b/scan_to_paperless/process.py
@@ -1719,10 +1719,10 @@ def _process(config_file_name: str, dirty: bool = False, print_waiting: bool = T
                     config["steps"].append(next_step)
                 save_config(config, config_file_name)
                 if done:
-                    with open(os.path.join(root_folder, "DONE"), "w"):
+                    with open(os.path.join(root_folder, "DONE"), "w", encoding="utf-8"):
                         pass
                 elif not disable_remove_to_continue:
-                    with open(os.path.join(root_folder, "REMOVE_TO_CONTINUE"), "w"):
+                    with open(os.path.join(root_folder, "REMOVE_TO_CONTINUE"), "w", encoding="utf-8"):
                         pass
 
     except Exception as exception:

--- a/scan_to_paperless/process.py
+++ b/scan_to_paperless/process.py
@@ -1638,7 +1638,7 @@ def save_config(config: schema.Configuration, config_file_name: str) -> None:
 
 
 def _process(config_file_name: str, dirty: bool = False, print_waiting: bool = True) -> Tuple[bool, bool]:
-    """Propcess one document."""
+    """Process one document."""
     if not os.path.exists(config_file_name):
         return dirty, print_waiting
 
@@ -1686,8 +1686,9 @@ def _process(config_file_name: str, dirty: bool = False, print_waiting: bool = T
         step = config["steps"][-1]
 
         if is_sources_present(step["sources"], root_folder):
-            if os.path.exists(os.path.join(root_folder, "REMOVE_TO_CONTINUE")) and not rerun:
-                return dirty, print_waiting
+            if config["args"]["no_remove_to_continue"] == True:
+                if os.path.exists(os.path.join(root_folder, "REMOVE_TO_CONTINUE")) and not rerun:
+                    return dirty, print_waiting
             if os.path.exists(os.path.join(root_folder, "DONE")) and not rerun:
                 return dirty, print_waiting
 
@@ -1714,12 +1715,13 @@ def _process(config_file_name: str, dirty: bool = False, print_waiting: bool = T
                 if next_step is not None:
                     config["steps"].append(next_step)
                 save_config(config, config_file_name)
-                with open(
-                    os.path.join(root_folder, "DONE" if done else "REMOVE_TO_CONTINUE"),
-                    "w",
-                    encoding="utf-8",
-                ):
-                    pass
+                if done:
+                    with open(os.path.join(root_folder, "DONE"), "w"):
+                        pass
+                elif config["args"]["no_remove_to_continue"] == True:
+                    with open(os.path.join(root_folder, "REMOVE_TO_CONTINUE"), "w"):
+                        pass
+
     except Exception as exception:
         print(exception)
         trace = traceback.format_exc()

--- a/scan_to_paperless/process_schema.json
+++ b/scan_to_paperless/process_schema.json
@@ -506,12 +506,6 @@
               "default": 6
             }
           }
-        },
-        "no_remove_to_continue": {
-          "type": "boolean",
-          "default": false,
-          "description": "Do not wait for the deletion of REMOVE_TO_CONTINUE before submitting the processed file",
-          "title": "Disable REMOVE_TO_CONTINUE"
         }
       }
     }

--- a/scan_to_paperless/process_schema.json
+++ b/scan_to_paperless/process_schema.json
@@ -506,6 +506,12 @@
               "default": 6
             }
           }
+        },
+        "no_remove_to_continue": {
+          "type": "boolean",
+          "default": false,
+          "description": "Do not wait for the deletion of REMOVE_TO_CONTINUE before submitting the processed file",
+          "title": "Disable REMOVE_TO_CONTINUE"
         }
       }
     }

--- a/scan_to_paperless/process_schema.json
+++ b/scan_to_paperless/process_schema.json
@@ -335,6 +335,12 @@
           "description": "The auto mask configuration, the mask is used to definitively mask the source image",
           "$ref": "#/definitions/auto_mask"
         },
+        "no_remove_to_continue": {
+          "type": "boolean",
+          "default": false,
+          "description": "Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf.",
+          "title": "No REMOVE_TO_CONTINUE"
+        },
         "deskew": {
           "type": "object",
           "description": "The deskew configuration",

--- a/scan_to_paperless/process_schema.py
+++ b/scan_to_paperless/process_schema.py
@@ -406,14 +406,6 @@ class Arguments(TypedDict, total=False):
     deskew: "_ArgumentsDeskew"
     line_detection: "LineDetection"
     rule: "Rule"
-    no_remove_to_continue: bool
-    """
-    Disable REMOVE_TO_CONTINUE.
-
-    Do not wait for the deletion of REMOVE_TO_CONTINUE before submitting the processed file
-
-    default: False
-    """
 
 
 class AssistedSplit(TypedDict, total=False):
@@ -630,10 +622,6 @@ DE_NOISE_MORPHOLOGY_DEFAULT = True
 
 DE_NOISE_SIZE_DEFAULT = 1000
 """ Default value of the field path 'Auto mask de_noise_size' """
-
-
-DISABLE_REMOVE_TO_CONTINUE_DEFAULT = False
-""" Default value of the field path 'Arguments no_remove_to_continue' """
 
 
 DITHER_DEFAULT = False

--- a/scan_to_paperless/process_schema.py
+++ b/scan_to_paperless/process_schema.py
@@ -406,6 +406,14 @@ class Arguments(TypedDict, total=False):
     deskew: "_ArgumentsDeskew"
     line_detection: "LineDetection"
     rule: "Rule"
+    no_remove_to_continue: bool
+    """
+    Disable REMOVE_TO_CONTINUE.
+
+    Do not wait for the deletion of REMOVE_TO_CONTINUE before submitting the processed file
+
+    default: False
+    """
 
 
 class AssistedSplit(TypedDict, total=False):
@@ -622,6 +630,10 @@ DE_NOISE_MORPHOLOGY_DEFAULT = True
 
 DE_NOISE_SIZE_DEFAULT = 1000
 """ Default value of the field path 'Auto mask de_noise_size' """
+
+
+DISABLE_REMOVE_TO_CONTINUE_DEFAULT = False
+""" Default value of the field path 'Arguments no_remove_to_continue' """
 
 
 DITHER_DEFAULT = False

--- a/scan_to_paperless/process_schema.py
+++ b/scan_to_paperless/process_schema.py
@@ -403,6 +403,15 @@ class Arguments(TypedDict, total=False):
 
     auto_mask: "AutoMask"
     auto_cut: "AutoMask"
+    no_remove_to_continue: bool
+    """
+    No REMOVE_TO_CONTINUE.
+
+    Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf.
+
+    default: False
+    """
+
     deskew: "_ArgumentsDeskew"
     line_detection: "LineDetection"
     rule: "Rule"
@@ -823,6 +832,10 @@ NO_AUTO_ROTATE_DEFAULT = False
 
 NO_CROP_DEFAULT = False
 """ Default value of the field path 'Arguments no_crop' """
+
+
+NO_REMOVE_TO_CONTINUE_DEFAULT = False
+""" Default value of the field path 'Arguments no_remove_to_continue' """
 
 
 PNGQUANT_OPTIONS_DEFAULT = ["--force", "--speed=1", "--strip", "--quality=0-32"]

--- a/scan_to_paperless/scan.py
+++ b/scan_to_paperless/scan.py
@@ -105,6 +105,12 @@ def main() -> None:
         help="Wait and convert clipboard content, used to fix the newlines in the copied codes, "
         "see requirement: https://pypi.org/project/pyperclip/",
     )
+    parser.add_argument(
+        "--no-remove-to-continue",
+        action="store_true",
+        default=False,
+        help="Don't wait for REMOVE_TO_CONTINUE's deletion before uploading to Paperless.",
+    )
 
     argcomplete.autocomplete(parser)
     args = parser.parse_args()


### PR DESCRIPTION
When the flag is set in `default_args` in the yaml file or passed on the command line to `scan`, it will be forwarded to the processor which will not wait before moving the PDF to the destination folder. Fixes #920 

I had to add a dependency to `typing-extensions` or the processor would crash on start. Not sure why this is needed now and not before. Maybe it's because of how I built it? I used `sudo make`.
I have left the commit separated in the PR so that you can drop it if it's not actually useful.