### PR TITLE
Added docker compose's override to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 /tests/img-0.png
 /tests/img-1.png
 /.github/changelog-generator-cache
+/docker-compose.override.yaml


### PR DESCRIPTION
Small change to ignore the `docker-compose.override.yaml` file that I use to run docker compose with my machine's config while developing.