### PR TITLE
Add support for uploading documents via REST API

### DIFF
--- a/config.md
+++ b/config.md
@@ -99,7 +99,7 @@
   - **`auto_cut`** _(object)_: The auto mask configuration, the mask is used to definitively mask the source image. Default: `{"enabled": false}`.
     - **`enabled`** _(boolean)_: Enable the auto cut. Default: `true`.
     - **`auto_mask`**: Refer to _[#/definitions/auto_mask](#definitions/auto_mask)_.
-  - **`no_remove_to_continue`** _(boolean)_: Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf. Default: `false`.
+  - **`no_remove_to_continue`** _(boolean)_: Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the PDF. Default: `false`.
   - **`deskew`** _(object)_: The deskew configuration.
     - **`min_angle`** _(number)_: The minimum angle to detect the image skew [degree]. Default: `-45`.
     - **`max_angle`** _(number)_: The maximum angle to detect the image skew [degree]. Default: `45`.
@@ -124,6 +124,12 @@
     - **`graduation_text_font_color`** _(array)_: Default: `[0, 0, 0]`.
       - **Items** _(integer)_
     - **`graduation_text_margin`** _(integer)_: Default: `6`.
+  - **`rest_upload`** _(object)_: Upload the final PDF via Paperless REST API.
+    - **`enabled`** _(boolean)_: Enable the upload of the PDF via REST API. Default: `false`.
+    - **`api_url`** _(string, required)_: The URL address of the REST API, usually http://server.name/api.
+    - **`api_token`** _(string, required)_: The API token.
+  - **`consume_folder`** _(object)_: Send the final PDF to Paperless using the consume folder.
+    - **`enabled`** _(boolean)_: Enable using the consume folder. Default: `true`.
 - <a id="definitions/contour"></a>**`contour`** _(object)_: The configuration used to find the contour.
   - **`min_box_size`** _(number)_: The minimum box size to find the content [mm]. Default: `{"crop": 3, "empty": 10, "limit": 10}`.
   - **`min_box_black`** _(number)_: The minimum black in a box on content find [%]. Default: `2`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -2921,6 +2921,31 @@ files = [
 ]
 
 [[package]]
+name = "types-requests"
+version = "2.31.0.2"
+description = "Typing stubs for requests"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-requests-2.31.0.2.tar.gz", hash = "sha256:6aa3f7faf0ea52d728bb18c0a0d1522d9bfd8c72d26ff6f61bfc3d06a411cf40"},
+    {file = "types_requests-2.31.0.2-py3-none-any.whl", hash = "sha256:56d181c85b5925cbc59f4489a57e72a8b2166f18273fd8ba7b6fe0c0b986f12a"},
+]
+
+[package.dependencies]
+types-urllib3 = "*"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.14"
+description = "Typing stubs for urllib3"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f"},
+    {file = "types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -3281,9 +3306,9 @@ files = [
 numpy = "*"
 
 [extras]
-process = ["Jinja2", "Pillow", "PyPDF2", "cffi", "deepmerge", "deskew", "matplotlib", "natsort", "nbformat", "opencv-contrib-python-headless", "pikepdf", "pyzbar", "reportlab", "typing-extensions", "weasyprint", "zxing-cpp"]
+process = ["Jinja2", "Pillow", "PyPDF2", "cffi", "deepmerge", "deskew", "matplotlib", "natsort", "nbformat", "opencv-contrib-python-headless", "pikepdf", "pyzbar", "reportlab", "requests", "typing-extensions", "weasyprint", "zxing-cpp"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "1e83c31dfebadcee50021877fe1f9969cd5f571df3b7b01c4dabbe8307c89702"
+content-hash = "1d2534d1114249baa7d4ed7d847fcb6c024fc4d46439490316a003eaf4e25a21"

--- a/process.md
+++ b/process.md
@@ -119,7 +119,7 @@
   - **`auto_cut`** _(object)_: The auto mask configuration, the mask is used to definitively mask the source image. Default: `{"enabled": false}`.
     - **`enabled`** _(boolean)_: Enable the auto cut. Default: `true`.
     - **`auto_mask`**: Refer to _[#/definitions/auto_mask](#definitions/auto_mask)_.
-  - **`no_remove_to_continue`** _(boolean)_: Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf. Default: `false`.
+  - **`no_remove_to_continue`** _(boolean)_: Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the PDF. Default: `false`.
   - **`deskew`** _(object)_: The deskew configuration.
     - **`min_angle`** _(number)_: The minimum angle to detect the image skew [degree]. Default: `-45`.
     - **`max_angle`** _(number)_: The maximum angle to detect the image skew [degree]. Default: `45`.
@@ -144,3 +144,9 @@
     - **`graduation_text_font_color`** _(array)_: Default: `[0, 0, 0]`.
       - **Items** _(integer)_
     - **`graduation_text_margin`** _(integer)_: Default: `6`.
+  - **`rest_upload`** _(object)_: Upload the final PDF via Paperless REST API.
+    - **`enabled`** _(boolean)_: Enable the upload of the PDF via REST API. Default: `false`.
+    - **`api_url`** _(string, required)_: The URL address of the REST API, usually http://server.name/api.
+    - **`api_token`** _(string, required)_: The API token.
+  - **`consume_folder`** _(object)_: Send the final PDF to Paperless using the consume folder.
+    - **`enabled`** _(boolean)_: Enable using the consume folder. Default: `true`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ typing-extensions = { version = "4.7.1", optional = true }
 Jinja2 = { version = "3.1.2", optional = true }
 natsort = { version = "8.4.0", optional = true }
 nbformat = { version = "5.9.2", optional = true }
+requests = { version = "2.31.0", optional = true }
 
 [tool.poetry.extras]
 process = [
@@ -82,7 +83,8 @@ process = [
     "typing-extensions",
     "Jinja2",
     "natsort",
-    "nbformat"
+    "nbformat",
+    "requests"
 ]
 
 [tool.poetry.group.dev.dependencies]
@@ -94,6 +96,7 @@ pytest-rerunfailures = "12.0"
 pyroma = "4.2"
 typing-extensions = "4.7.1"
 c2cwsgiutils = { version = "6.0.0.dev142", extras = ["test_images"] }
+types-requests = "2.31.0.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning", "poetry-plugin-tweak-dependencies-version"]

--- a/scan_to_paperless/config.py
+++ b/scan_to_paperless/config.py
@@ -4,6 +4,8 @@
 
 from typing import TypedDict, Union
 
+from typing_extensions import Required
+
 APPEND_CREDIT_CARD_DEFAULT = False
 """ Default value of the field path 'Arguments append_credit_card' """
 
@@ -163,13 +165,15 @@ class Arguments(TypedDict, total=False):
     """
     No REMOVE_TO_CONTINUE.
 
-    Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf.
+    Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the PDF.
 
     default: False
     """
 
     deskew: "_ArgumentsDeskew"
     rule: "Rule"
+    rest_upload: "RestUpload"
+    consume_folder: "ConsumeFolder"
 
 
 class AutoCut(TypedDict, total=False):
@@ -334,6 +338,10 @@ COLORS_DEFAULT = 0
 """ Default value of the field path 'Arguments colors' """
 
 
+CONSUME_FOLDER_ENABLED_DEFAULT = True
+""" Default value of the field path 'Consume folder enabled' """
+
+
 CONTOUR_KERNEL_SIZE_DEFAULT = 1.5
 """ Default value of the field path 'Contour contour_kernel_size' """
 
@@ -421,6 +429,23 @@ class Configuration(TypedDict, total=False):
       one:
         scanimage_arguments:
         - --batch-count=1
+    """
+
+
+class ConsumeFolder(TypedDict, total=False):
+    """
+    Consume folder.
+
+    Send the final PDF to Paperless using the consume folder
+    """
+
+    enabled: bool
+    """
+    Consume folder enabled.
+
+    Enable using the consume folder
+
+    default: True
     """
 
 
@@ -1019,6 +1044,10 @@ class Ps2Pdf(TypedDict, total=False):
     """
 
 
+REST_UPLOAD_ENABLED_DEFAULT = False
+""" Default value of the field path 'REST upload enabled' """
+
+
 ROTATE_EVEN_DEFAULT = False
 """ Default value of the field path 'Mode rotate_even' """
 
@@ -1073,6 +1102,41 @@ RULE_MINOR_GRADUATION_SIZE_DEFAULT = 10
 
 RULE_MINOR_GRADUATION_SPACE_DEFAULT = 10
 """ Default value of the field path 'Rule minor_graduation_space' """
+
+
+class RestUpload(TypedDict, total=False):
+    """
+    REST upload.
+
+    Upload the final PDF via Paperless REST API
+    """
+
+    enabled: bool
+    """
+    REST upload enabled.
+
+    Enable the upload of the PDF via REST API
+
+    default: False
+    """
+
+    api_url: Required[str]
+    """
+    REST upload API url.
+
+    The URL address of the REST API, usually http://server.name/api
+
+    Required property
+    """
+
+    api_token: Required[str]
+    """
+    REST upload API token.
+
+    The API token
+
+    Required property
+    """
 
 
 class Rule(TypedDict, total=False):

--- a/scan_to_paperless/config_schema.json
+++ b/scan_to_paperless/config_schema.json
@@ -443,7 +443,7 @@
         "no_remove_to_continue": {
           "type": "boolean",
           "default": false,
-          "description": "Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf.",
+          "description": "Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the PDF.",
           "title": "No REMOVE_TO_CONTINUE"
         },
         "deskew": {
@@ -488,7 +488,6 @@
             }
           }
         },
-
         "rule": {
           "type": "object",
           "title": "Rule",
@@ -567,6 +566,43 @@
               "title": "Rule graduation text margin",
               "type": "integer",
               "default": 6
+            }
+          }
+        },
+        "rest_upload": {
+          "type": "object",
+          "title": "REST upload",
+          "description": "Upload the final PDF via Paperless REST API",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable the upload of the PDF via REST API",
+              "title": "REST upload enabled"
+            },
+            "api_url": {
+              "type": "string",
+              "description": "The URL address of the REST API, usually http://server.name/api",
+              "title": "REST upload API url"
+            },
+            "api_token": {
+              "type": "string",
+              "description": "The API token",
+              "title": "REST upload API token"
+            }
+          },
+          "required": ["api_url", "api_token"]
+        },
+        "consume_folder": {
+          "type": "object",
+          "title": "Consume folder",
+          "description": "Send the final PDF to Paperless using the consume folder",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Enable using the consume folder",
+              "title": "Consume folder enabled"
             }
           }
         }

--- a/scan_to_paperless/process_schema.json
+++ b/scan_to_paperless/process_schema.json
@@ -485,7 +485,7 @@
         "no_remove_to_continue": {
           "type": "boolean",
           "default": false,
-          "description": "Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf.",
+          "description": "Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the PDF.",
           "title": "No REMOVE_TO_CONTINUE"
         },
         "deskew": {
@@ -608,6 +608,43 @@
               "title": "Rule graduation text margin",
               "type": "integer",
               "default": 6
+            }
+          }
+        },
+        "rest_upload": {
+          "type": "object",
+          "title": "REST upload",
+          "description": "Upload the final PDF via Paperless REST API",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable the upload of the PDF via REST API",
+              "title": "REST upload enabled"
+            },
+            "api_url": {
+              "type": "string",
+              "description": "The URL address of the REST API, usually http://server.name/api",
+              "title": "REST upload API url"
+            },
+            "api_token": {
+              "type": "string",
+              "description": "The API token",
+              "title": "REST upload API token"
+            }
+          },
+          "required": ["api_url", "api_token"]
+        },
+        "consume_folder": {
+          "type": "object",
+          "title": "Consume folder",
+          "description": "Send the final PDF to Paperless using the consume folder",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Enable using the consume folder",
+              "title": "Consume folder enabled"
             }
           }
         }

--- a/scan_to_paperless/process_schema.py
+++ b/scan_to_paperless/process_schema.py
@@ -165,13 +165,15 @@ class Arguments(TypedDict, total=False):
     """
     No REMOVE_TO_CONTINUE.
 
-    Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the pdf.
+    Don't wait for the deletion of the REMOVE_TO_CONTINUE file before exporting the PDF.
 
     default: False
     """
 
     deskew: "_ArgumentsDeskew"
     rule: "Rule"
+    rest_upload: "RestUpload"
+    consume_folder: "ConsumeFolder"
 
 
 class AssistedSplit(TypedDict, total=False):
@@ -364,6 +366,10 @@ COLORS_DEFAULT = 0
 """ Default value of the field path 'Arguments colors' """
 
 
+CONSUME_FOLDER_ENABLED_DEFAULT = True
+""" Default value of the field path 'Consume folder enabled' """
+
+
 CONTOUR_KERNEL_SIZE_DEFAULT = 1.5
 """ Default value of the field path 'Contour contour_kernel_size' """
 
@@ -413,6 +419,23 @@ class Configuration(TypedDict, total=False):
     """ The ignored errors """
 
     images_config: dict[str, "_ConfigurationImagesConfigAdditionalproperties"]
+
+
+class ConsumeFolder(TypedDict, total=False):
+    """
+    Consume folder.
+
+    Send the final PDF to Paperless using the consume folder
+    """
+
+    enabled: bool
+    """
+    Consume folder enabled.
+
+    Enable using the consume folder
+
+    default: True
+    """
 
 
 class Contour(TypedDict, total=False):
@@ -942,6 +965,10 @@ class Ps2Pdf(TypedDict, total=False):
     """
 
 
+REST_UPLOAD_ENABLED_DEFAULT = False
+""" Default value of the field path 'REST upload enabled' """
+
+
 RULE_ENABLE_DEFAULT = True
 """ Default value of the field path 'Rule enabled' """
 
@@ -992,6 +1019,41 @@ RULE_MINOR_GRADUATION_SIZE_DEFAULT = 10
 
 RULE_MINOR_GRADUATION_SPACE_DEFAULT = 10
 """ Default value of the field path 'Rule minor_graduation_space' """
+
+
+class RestUpload(TypedDict, total=False):
+    """
+    REST upload.
+
+    Upload the final PDF via Paperless REST API
+    """
+
+    enabled: bool
+    """
+    REST upload enabled.
+
+    Enable the upload of the PDF via REST API
+
+    default: False
+    """
+
+    api_url: Required[str]
+    """
+    REST upload API url.
+
+    The URL address of the REST API, usually http://server.name/api
+
+    Required property
+    """
+
+    api_token: Required[str]
+    """
+    REST upload API token.
+
+    The API token
+
+    Required property
+    """
 
 
 class Rule(TypedDict, total=False):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -446,9 +446,10 @@ def test_full(progress):
     creator_tesseract_re = re.compile(r"^Tesseract 4.[0-9]+.[0-9]+$")
     with pikepdf.open(pdf_filename) as pdf_:
         with pdf_.open_metadata() as meta:
-            assert len(meta["{http://purl.org/dc/elements/1.1/}creator"]) == 2
-            assert creator_scan_tp_paperless_re.match(meta["{http://purl.org/dc/elements/1.1/}creator"][0])
-            assert creator_tesseract_re.match(meta["{http://purl.org/dc/elements/1.1/}creator"][1])
+            creator = meta["{http://purl.org/dc/elements/1.1/}creator"]
+            assert len(creator) == 2, creator
+            assert creator_scan_tp_paperless_re.match(creator[0]), creator
+            assert creator_tesseract_re.match(creator[1]), creator
 
     pdfinfo = process.output(["pdfinfo", pdf_filename]).split("\n")
     regex = re.compile(r"([a-zA-Z ]+): +(.*)")


### PR DESCRIPTION
This change adds support to push the documents to Paperless via the REST API.
This makes it easy to run the processor jobs on a different machine from paperless without having to share a folder.
Fixes: #1021 