### PR TITLE
Free matplotlib allocations at the end of the processing step.

### DIFF
--- a/scan_to_paperless/process.py
+++ b/scan_to_paperless/process.py
@@ -1281,6 +1281,10 @@ def transform(
 
         images = new_images
 
+    # Free matplotlib allocations
+    plt.clf()
+    plt.close("all")
+
     return {
         "sources": images,
         "name": "split"


### PR DESCRIPTION
Matplotlib kept using more and more memory, and the process was eating up all of the system memory after a while.\
After this fix the memory consumption is constant.
Fixes: #1025 