### PR TITLE
Snyk auto fix

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -7,3 +7,5 @@ poetry-plugin-export==1.5.0
 pip==23.3.1
 pre-commit==3.4.0
 poetry-plugin-drop-python-upper-constraint==0.1.0
+certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/poetry.lock
+++ b/poetry.lock
@@ -3638,13 +3638,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.5"
+version = "2.0.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.5-py3-none-any.whl", hash = "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"},
-    {file = "urllib3-2.0.5.tar.gz", hash = "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594"},
+    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
+    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
 ]
 
 [package.extras]
@@ -3906,4 +3906,4 @@ process = ["Jinja2", "Pillow", "PyPDF2", "cffi", "deepmerge", "deskew", "matplot
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "c5ea5d5cc674cab4cbaed54991aaa6199583d9f12eec43acaae1764b10cb7e32"
+content-hash = "4c512f95f03584dbb3ff1b5d0e69cc52828b80dc0394269764ae52bf1bca7fcf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ Jinja2 = { version = "3.1.2", optional = true }
 natsort = { version = "8.4.0", optional = true }
 nbformat = { version = "5.9.2", optional = true }
 requests = { version = "2.31.0", optional = true }
+urllib3 = "2.0.7"
 
 [tool.poetry.extras]
 process = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ poetry-plugin-tweak-dependencies-version==1.5.1
 poetry-dynamic-versioning==1.1.1
 poetry-plugin-export==1.5.0
 pip==23.3.1
+certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
⠋ Running `snyk test` for /home/runner/work/scan-to-paperless/scan-to-paperless
► Running `snyk test` for /home/runner/work/scan-to-paperless/scan-to-paperless
- Looking for supported Python items

✔ Looking for supported Python items
- Looking for supported Python items

✔ Looking for supported Python items
⠋ Processing 1 pyproject.toml items⠋ Processing 2 requirements.txt items✔ Processed 2 requirements.txt items
- Checking poetry version
⚠️ Could not detect poetry version, proceeding anyway. Some operations may fail.
- Fixing pyproject.toml 1/1
✔ Processed 1 pyproject.toml items
✔ Done

Successful fixes:

  pyproject.toml
  ✔ Upgraded opencv-contrib-python-headless from 4.7.0.72 to 4.8.1.78

Summary:

  1 items were successfully fixed

  5 issues: 1 Critical | 2 Medium | 2 Low
  1 issues are fixable
  1 issues were successfully fixed