### PR TITLE
Fix mypy type errors with deepmerge 2.1.0

### DIFF
--- a/scan_to_paperless/__init__.py
+++ b/scan_to_paperless/__init__.py
@@ -41,7 +41,7 @@ async def get_config(config_filename: Path, verbose: bool = True) -> schema.Conf
                 )
 
                 strategies_config = config.get("merge_strategies", cast("schema.MergeStrategies", {}))
-                merger = Merger(
+                merger = Merger(  # type: ignore[arg-type]
                     [
                         (list, strategies_config.get("for_list", ["override"])),
                         (dict, strategies_config.get("for_dict", ["merge"])),


### PR DESCRIPTION
Fixes mypy errors in `scan_to_paperless/__init__.py` caused by deepmerge 2.1.0's stricter type annotations.

The `Merger` constructor expects `list[str | Callable]` but the config passes `list[str]`. Added `# type: ignore[arg-type]` to suppress the check since the values at runtime are correct.

Fixes #1999

<!-- pull request links -->
See JIRA issue: [DEEPMERGE-1999](https://camptocamp.atlassian.net/browse/DEEPMERGE-1999).