### PR TITLE
Enable dockerfile manager explicitly in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,12 @@
     'github>camptocamp/gs-renovate-config-preset:security.json5#1.10.1',
   ],
   baseBranchPatterns: ['test', 'master'],
+  dockerfile: {
+    enabled: true,
+  },
+  docker: {
+    enabled: true,
+  },
   packageRules: [
     /** Accept only the patch on stabilization branches */
     {


### PR DESCRIPTION
## Problem

Renovate detects the `Dockerfile` but extracts zero dependencies from it — `FROM ubuntu:24.04` is not being picked up.

The Dependency Dashboard shows:
- `dockerfile (1)` → `Dockerfile` (empty, no dependencies listed)

## Changes

Added explicit `dockerfile.enabled: true` and `docker.enabled: true` to ensure the docker managers are active. The preset `gs-renovate-config-preset:base.json5#1.10.1` already has the correct LTS filtering rules (from PR camptocamp/gs-renovate-config-preset#125), but a local override was still needed to guarantee the managers are not disabled.