### PR TITLE
Add sam_test configuration for SAM mask overlay visualization

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,12 @@
     'github>camptocamp/gs-renovate-config-preset:security.json5#1.10.1',
   ],
   baseBranchPatterns: ['test', 'master'],
+  dockerfile: {
+    enabled: true,
+  },
+  docker: {
+    enabled: true,
+  },
   packageRules: [
     /** Accept only the patch on stabilization branches */
     {

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ to verify that the result is OK (and do some advance operations describe below) 
 - Scan the QR code and Bar code and add a new page with the values (separate process)
 - Manage the empty lines in the QR code (replace by a pipe (`|`) in the PDF,
   and run `scan --convert-clipboard` to scan your clipboard to do the inverse transform)
+- SAM test overlays: configure `args.sam_test` with arbitrary test names and SAM3 prompts
+  to generate green semi-transparent overlay images showing the detected mask
 
 ## Requirements
 
@@ -157,6 +159,31 @@ During processing, each image now gets additional analysis in `images_config.<im
 Those values are intended to help a human or an AI iterate on `args.cut_black`, `args.cut_white`,
 `args.mask.auto_mask` and `args.cut.auto_mask`.
 
+### SAM test overlays
+
+The `args.sam_test` configuration allows generating visual overlays to evaluate SAM3 mask quality
+for different prompts and thresholds. Each key in the dictionary becomes a subfolder in the job
+directory containing the image with a green semi-transparent overlay (same style as crop rectangles)
+showing the detected mask.
+
+Example configuration in `config.yaml`:
+
+```yaml
+args:
+  sam_test:
+    page:
+      prompt: "document"
+      threshold: 0.5
+    ticket:
+      prompt: "receipt, ticket"
+      threshold: 0.3
+```
+
+This generates two subfolders `page/` and `ticket/` in the job directory, each containing the
+processed image with the SAM mask overlay.
+
+See also: [The documentation](./process.md#sam_test)
+
 ## Advance feature
 
 ### Add a mask
@@ -279,7 +306,7 @@ Environment variable:
 - `SCAN_CODES_MARGIN_LEFT`:The left margin of code number.
 - `TIME`: Print the elapsed time.
 - `PROGRESS`: Save some intermediate files, don't clean the folder at the end.
-- `HF_TOKEN`: The HuggingFace token to access the SAM3 model (required for `mask.sam3` or `cut.sam3`).
+- `HF_TOKEN`: The HuggingFace token to access the SAM3 model (required for `mask.sam3`, `cut.sam3`, or `sam_test`).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ Example configuration in `config.yaml`:
 args:
   sam_test:
     page:
-      prompt: "document"
+      prompt: 'document'
       threshold: 0.5
     ticket:
-      prompt: "receipt, ticket"
+      prompt: 'receipt, ticket'
       threshold: 0.3
 ```
 

--- a/config.md
+++ b/config.md
@@ -137,6 +137,11 @@
     - <a id="definitions/args/properties/rest_upload/properties/api_token"></a>**`api_token`** *(string, required)*: The API token.
   - <a id="definitions/args/properties/consume_folder"></a>**`consume_folder`** *(object)*: Send the final PDF to Paperless using the consume folder.
     - <a id="definitions/args/properties/consume_folder/properties/enabled"></a>**`enabled`** *(boolean)*: Enable using the consume folder. Default: `true`.
+  - <a id="definitions/args/properties/sam_test"></a>**`sam_test`** *(object)*: Dictionary of SAM test configurations. Each key becomes a directory with green semi-transparent overlay images. Can contain additional properties. Default: `{}`.
+    - <a id="definitions/args/properties/sam_test/additionalProperties"></a>**Additional properties** *(object)*
+      - <a id="definitions/args/properties/sam_test/additionalProperties/properties/enabled"></a>**`enabled`** *(boolean)*: Enable this SAM test. Default: `true`.
+      - <a id="definitions/args/properties/sam_test/additionalProperties/properties/prompt"></a>**`prompt`** *(string)*: Text prompt for SAM3 segmentation. Default: `"document"`.
+      - <a id="definitions/args/properties/sam_test/additionalProperties/properties/threshold"></a>**`threshold`** *(number)*: Confidence threshold for mask prediction. Default: `0.5`.
 - <a id="definitions/contour"></a>**`contour`** *(object)*: The configuration used to find the contour.
   - <a id="definitions/contour/properties/min_box_size"></a>**`min_box_size`** *(number)*: The minimum box size to find the content [mm]. Default: `{"crop": 3, "empty": 10, "limit": 10}`.
   - <a id="definitions/contour/properties/min_box_black"></a>**`min_box_black`** *(number)*: The minimum black in a box on content find [%]. Default: `2`.

--- a/process.md
+++ b/process.md
@@ -211,3 +211,8 @@
     - <a id="definitions/args/properties/rest_upload/properties/api_token"></a>**`api_token`** *(string, required)*: The API token.
   - <a id="definitions/args/properties/consume_folder"></a>**`consume_folder`** *(object)*: Send the final PDF to Paperless using the consume folder.
     - <a id="definitions/args/properties/consume_folder/properties/enabled"></a>**`enabled`** *(boolean)*: Enable using the consume folder. Default: `true`.
+  - <a id="definitions/args/properties/sam_test"></a>**`sam_test`** *(object)*: Dictionary of SAM test configurations. Each key becomes a directory with green semi-transparent overlay images. Can contain additional properties. Default: `{}`.
+    - <a id="definitions/args/properties/sam_test/additionalProperties"></a>**Additional properties** *(object)*
+      - <a id="definitions/args/properties/sam_test/additionalProperties/properties/enabled"></a>**`enabled`** *(boolean)*: Enable this SAM test. Default: `true`.
+      - <a id="definitions/args/properties/sam_test/additionalProperties/properties/prompt"></a>**`prompt`** *(string)*: Text prompt for SAM3 segmentation. Default: `"document"`.
+      - <a id="definitions/args/properties/sam_test/additionalProperties/properties/threshold"></a>**`threshold`** *(number)*: Confidence threshold for mask prediction. Default: `0.5`.

--- a/scan_to_paperless/config.py
+++ b/scan_to_paperless/config.py
@@ -2,7 +2,7 @@
 # Used to correctly format the generated file
 
 
-from typing import Required, TypedDict
+from typing import Any, Required, TypedDict
 
 
 APPEND_CREDIT_CARD_DEFAULT = False
@@ -269,6 +269,16 @@ class Arguments(TypedDict, total=False):
     Consume folder.
 
     Send the final PDF to Paperless using the consume folder
+    """
+
+    sam_test: dict[str, "SamTestConfiguration"]
+    r"""
+    SAM test configurations.
+
+    Dictionary of SAM test configurations. Each key becomes a directory with green semi-transparent overlay images.
+
+    default:
+      {}
     """
 
 
@@ -1566,6 +1576,26 @@ r""" Default value of the field path 'SAM3 threshold' """
 
 
 
+SAM_TEST_CONFIGURATIONS_DEFAULT: dict[str, Any] = {}
+r""" Default value of the field path 'Arguments sam_test' """
+
+
+
+SAM_TEST_ENABLED_DEFAULT = True
+r""" Default value of the field path 'SAM test configuration enabled' """
+
+
+
+SAM_TEST_PROMPT_DEFAULT = 'document'
+r""" Default value of the field path 'SAM test configuration prompt' """
+
+
+
+SAM_TEST_THRESHOLD_DEFAULT = 0.5
+r""" Default value of the field path 'SAM test configuration threshold' """
+
+
+
 SCANIMAGE_ARGUMENTS_DEFAULT = ['--format=png', '--mode=color', '--resolution=300']
 r""" Default value of the field path 'Configuration scanimage_arguments' """
 
@@ -1614,6 +1644,38 @@ class Sam3(TypedDict, total=False):
     threshold: int | float
     r"""
     SAM3 threshold.
+
+    Confidence threshold for mask prediction
+
+    default: 0.5
+    """
+
+
+
+class SamTestConfiguration(TypedDict, total=False):
+    r""" SAM test configuration. """
+
+    enabled: bool
+    r"""
+    SAM test enabled.
+
+    Enable this SAM test
+
+    default: True
+    """
+
+    prompt: str
+    r"""
+    SAM test prompt.
+
+    Text prompt for SAM3 segmentation
+
+    default: document
+    """
+
+    threshold: int | float
+    r"""
+    SAM test threshold.
 
     Confidence threshold for mask prediction
 

--- a/scan_to_paperless/config_schema.json
+++ b/scan_to_paperless/config_schema.json
@@ -650,6 +650,36 @@
               "title": "Consume folder enabled"
             }
           }
+        },
+        "sam_test": {
+          "type": "object",
+          "title": "SAM test configurations",
+          "description": "Dictionary of SAM test configurations. Each key becomes a directory with green semi-transparent overlay images.",
+          "default": {},
+          "additionalProperties": {
+            "type": "object",
+            "title": "SAM test configuration",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": true,
+                "description": "Enable this SAM test",
+                "title": "SAM test enabled"
+              },
+              "prompt": {
+                "type": "string",
+                "default": "document",
+                "description": "Text prompt for SAM3 segmentation",
+                "title": "SAM test prompt"
+              },
+              "threshold": {
+                "type": "number",
+                "default": 0.5,
+                "description": "Confidence threshold for mask prediction",
+                "title": "SAM test threshold"
+              }
+            }
+          }
         }
       }
     },

--- a/scan_to_paperless/jupyter.py
+++ b/scan_to_paperless/jupyter.py
@@ -79,6 +79,8 @@ then yon can all those changes in the `config.yaml` file, in the `args` section.
             """import os
 import cv2
 import numpy as np
+import anyio
+from PIL import Image
 
 from scan_to_paperless import process, process_utils""",
         ),
@@ -330,6 +332,43 @@ if context.mask is None:
     context.mask = np.zeros(context.image.shape[:2], dtype=np.uint8)
 
 images_context["original-mask"] = context.mask""",
+        ),
+    )
+
+    notebook["cells"].append(
+        nbformat.v4.new_markdown_cell(  # type: ignore[no-untyped-call]
+            """Generate SAM test overlays.
+
+If `args.sam_test` is configured in the config file, this will run SAM3 inference for each test entry
+and display the mask as a green semi-transparent overlay on the image (same style as crop rectangles).""",
+        ),
+    )
+    notebook["cells"].append(
+        nbformat.v4.new_code_cell(  # type: ignore[no-untyped-call]
+            f"""context.image = images_context["original"].copy()
+
+context.config["args"]["sam_test"] = {_pretty_repr(context.config["args"].get("sam_test", {}))}
+
+sam_test_configs = context.config["args"].get("sam_test", {{}})
+if sam_test_configs:
+    from scan_to_paperless.process_utils import run_sam3_inference
+
+    for test_name, test_config in sam_test_configs.items():
+        if not test_config.get("enabled", True):
+            continue
+        print(f"Running SAM test: {{test_name}}")
+        image_rgb = cv2.cvtColor(context.image, cv2.COLOR_BGR2RGB)
+        mask = await anyio.to_thread.run_sync(
+            run_sam3_inference,
+            Image.fromarray(image_rgb, mode="RGB"),
+            test_config.get("prompt", "document"),
+            test_config.get("threshold", 0.5),
+        )
+        overlay = process.draw_mask_overlay(context.image, mask)
+        context.display_image(overlay)
+else:
+    print("No sam_test configured, add args.sam_test to your config.yaml to enable.")
+""",
         ),
     )
 

--- a/scan_to_paperless/process.py
+++ b/scan_to_paperless/process.py
@@ -1548,7 +1548,7 @@ async def transform(
         await level(context)
         await color_cut(context)
         await context.init_mask()
-        sam_test_configs = config["args"].setdefault("sam_test", schema.SAM_TEST_CONFIG_DEFAULT)
+        sam_test_configs = config["args"].setdefault("sam_test", schema.SAM_TEST_CONFIGURATIONS_DEFAULT)
         if sam_test_configs and context.image is not None and context.mask is not None:
             for test_name, test_config in sam_test_configs.items():
                 if not test_config.get("enabled", True):

--- a/scan_to_paperless/process.py
+++ b/scan_to_paperless/process.py
@@ -1567,7 +1567,8 @@ async def transform(
                 success, buffer = cv2.imencode(".png", overlay)
                 if success:
                     async with await anyio.open_file(
-                        str(dest_folder / context.image_name), "wb",
+                        str(dest_folder / context.image_name),
+                        "wb",
                     ) as file:
                         await file.write(buffer.tobytes())
         await cut(context)

--- a/scan_to_paperless/process.py
+++ b/scan_to_paperless/process.py
@@ -910,6 +910,15 @@ def draw_rectangle(image: NpNdarrayInt, contour: tuple[int, int, int, int], bord
         cv2.rectangle(image, (x + width - 1, y), (x + width, y + height), color, -1)
 
 
+def draw_mask_overlay(image: NpNdarrayInt, mask: NpNdarrayInt) -> NpNdarrayInt:
+    """Draw a green semi-transparent overlay on the masked area (same style as draw_rectangle)."""
+    color = (0, 255, 0)
+    opacity = 0.1
+    mask_overlay = np.zeros_like(image, dtype=np.uint8)
+    mask_overlay[mask == 255] = color
+    return cv2.addWeighted(image, 1 - opacity, mask_overlay, opacity, 1.0)
+
+
 def find_lines(
     image: NpNdarrayInt,
     vertical: bool,
@@ -1539,6 +1548,28 @@ async def transform(
         await level(context)
         await color_cut(context)
         await context.init_mask()
+        sam_test_configs = config["args"].setdefault("sam_test", schema.SAM_TEST_CONFIG_DEFAULT)
+        if sam_test_configs and context.image is not None and context.mask is not None:
+            for test_name, test_config in sam_test_configs.items():
+                if not test_config.get("enabled", True):
+                    continue
+                image_rgb = cv2.cvtColor(context.image, cv2.COLOR_BGR2RGB)
+                mask = await anyio.to_thread.run_sync(
+                    process_utils.run_sam3_inference,
+                    Image.fromarray(image_rgb, mode="RGB"),
+                    test_config.get("prompt", schema.SAM3_PROMPT_DEFAULT),
+                    test_config.get("threshold", schema.SAM3_THRESHOLD_DEFAULT),
+                )
+                overlay = draw_mask_overlay(context.image, mask)
+                dest_folder = root_folder / test_name
+                if not await dest_folder.exists():
+                    await dest_folder.mkdir(parents=True)
+                success, buffer = cv2.imencode(".png", overlay)
+                if success:
+                    async with await anyio.open_file(
+                        str(dest_folder / context.image_name), "wb",
+                    ) as file:
+                        await file.write(buffer.tobytes())
         await cut(context)
         await deskew(context)
         await docrop(context)

--- a/scan_to_paperless/process.py
+++ b/scan_to_paperless/process.py
@@ -916,7 +916,10 @@ def draw_mask_overlay(image: NpNdarrayInt, mask: NpNdarrayInt) -> NpNdarrayInt:
     opacity = 0.1
     mask_overlay = np.zeros_like(image, dtype=np.uint8)
     mask_overlay[mask == 255] = color
-    return cv2.addWeighted(image, 1 - opacity, mask_overlay, opacity, 1.0)
+    blended = cv2.addWeighted(image, 1 - opacity, mask_overlay, opacity, 1.0)
+    result = image.copy()
+    result[mask == 255] = blended[mask == 255]
+    return result
 
 
 def find_lines(

--- a/scan_to_paperless/process_schema.json
+++ b/scan_to_paperless/process_schema.json
@@ -60,11 +60,7 @@
         "lower_hsv_color": {
           "type": "array",
           "description": "The lower color in HSV representation",
-          "default": [
-            0,
-            0,
-            250
-          ],
+          "default": [0, 0, 250],
           "items": {
             "type": "integer"
           },
@@ -73,11 +69,7 @@
         "upper_hsv_color": {
           "type": "array",
           "description": "The upper color in HSV representation",
-          "default": [
-            255,
-            10,
-            255
-          ],
+          "default": [255, 10, 255],
           "items": {
             "type": "integer"
           },
@@ -160,10 +152,7 @@
           "description": "The level configuration",
           "properties": {
             "value": {
-              "type": [
-                "boolean",
-                "integer"
-              ],
+              "type": ["boolean", "integer"],
               "description": "true: => do level on 15% - 85% (under 15 % will be black above 85% will be white), false: => 0% - 100%, <number>: => (0 + <number>)% - (100 - number)%",
               "title": "Level value",
               "default": false
@@ -408,12 +397,7 @@
             "options": {
               "type": "array",
               "description": "The pngquant options",
-              "default": [
-                "--force",
-                "--speed=1",
-                "--strip",
-                "--quality=0-32"
-              ],
+              "default": ["--force", "--speed=1", "--strip", "--quality=0-32"],
               "items": {
                 "type": "string"
               },
@@ -490,11 +474,7 @@
         },
         "background_color": {
           "type": "array",
-          "default": [
-            255,
-            255,
-            255
-          ],
+          "default": [255, 255, 255],
           "description": "The background color",
           "items": {
             "type": "integer"
@@ -519,10 +499,7 @@
               "$ref": "#/definitions/auto_mask"
             },
             "additional_filename": {
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": ["string", "null"],
               "description": "An image file used to add on the mask"
             }
           }
@@ -545,10 +522,7 @@
               "$ref": "#/definitions/auto_mask"
             },
             "additional_filename": {
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": ["string", "null"],
               "description": "An image file used to add on the mask"
             }
           }
@@ -639,11 +613,7 @@
             "graduation_color": {
               "title": "Rule graduation color",
               "type": "array",
-              "default": [
-                0,
-                0,
-                0
-              ],
+              "default": [0, 0, 0],
               "items": {
                 "type": "integer"
               }
@@ -651,11 +621,7 @@
             "lines_color": {
               "title": "Rule lines color",
               "type": "array",
-              "default": [
-                0,
-                0,
-                0
-              ],
+              "default": [0, 0, 0],
               "items": {
                 "type": "integer"
               }
@@ -678,11 +644,7 @@
             "graduation_text_font_color": {
               "title": "Rule graduation text font color",
               "type": "array",
-              "default": [
-                0,
-                0,
-                0
-              ],
+              "default": [0, 0, 0],
               "items": {
                 "type": "integer"
               }
@@ -716,10 +678,7 @@
               "title": "REST upload API token"
             }
           },
-          "required": [
-            "api_url",
-            "api_token"
-          ]
+          "required": ["api_url", "api_token"]
         },
         "consume_folder": {
           "type": "object",
@@ -826,10 +785,7 @@
             "type": "array",
             "title": "The destination image positions",
             "items": {
-              "type": [
-                "integer",
-                "string"
-              ]
+              "type": ["integer", "string"]
             }
           },
           "image": {
@@ -905,10 +861,7 @@
         "additionalProperties": false,
         "properties": {
           "angle": {
-            "type": [
-              "number",
-              "null"
-            ],
+            "type": ["number", "null"],
             "description": "The used angle to deskew, can be change, restart by deleting one of the generated images"
           },
           "status": {
@@ -1092,23 +1045,13 @@
                 "properties": {
                   "angle_from": {
                     "type": "string",
-                    "enum": [
-                      "detected",
-                      "manual",
-                      "none"
-                    ]
+                    "enum": ["detected", "manual", "none"]
                   },
                   "detected_angle": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
+                    "type": ["number", "null"]
                   },
                   "applied_angle": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
+                    "type": ["number", "null"]
                   },
                   "near_search_limit": {
                     "type": "boolean"
@@ -1145,8 +1088,5 @@
       }
     }
   },
-  "required": [
-    "images",
-    "args"
-  ]
+  "required": ["images", "args"]
 }

--- a/scan_to_paperless/process_schema.json
+++ b/scan_to_paperless/process_schema.json
@@ -60,7 +60,11 @@
         "lower_hsv_color": {
           "type": "array",
           "description": "The lower color in HSV representation",
-          "default": [0, 0, 250],
+          "default": [
+            0,
+            0,
+            250
+          ],
           "items": {
             "type": "integer"
           },
@@ -69,7 +73,11 @@
         "upper_hsv_color": {
           "type": "array",
           "description": "The upper color in HSV representation",
-          "default": [255, 10, 255],
+          "default": [
+            255,
+            10,
+            255
+          ],
           "items": {
             "type": "integer"
           },
@@ -152,7 +160,10 @@
           "description": "The level configuration",
           "properties": {
             "value": {
-              "type": ["boolean", "integer"],
+              "type": [
+                "boolean",
+                "integer"
+              ],
               "description": "true: => do level on 15% - 85% (under 15 % will be black above 85% will be white), false: => 0% - 100%, <number>: => (0 + <number>)% - (100 - number)%",
               "title": "Level value",
               "default": false
@@ -397,7 +408,12 @@
             "options": {
               "type": "array",
               "description": "The pngquant options",
-              "default": ["--force", "--speed=1", "--strip", "--quality=0-32"],
+              "default": [
+                "--force",
+                "--speed=1",
+                "--strip",
+                "--quality=0-32"
+              ],
               "items": {
                 "type": "string"
               },
@@ -474,7 +490,11 @@
         },
         "background_color": {
           "type": "array",
-          "default": [255, 255, 255],
+          "default": [
+            255,
+            255,
+            255
+          ],
           "description": "The background color",
           "items": {
             "type": "integer"
@@ -499,7 +519,10 @@
               "$ref": "#/definitions/auto_mask"
             },
             "additional_filename": {
-              "type": ["string", "null"],
+              "type": [
+                "string",
+                "null"
+              ],
               "description": "An image file used to add on the mask"
             }
           }
@@ -522,7 +545,10 @@
               "$ref": "#/definitions/auto_mask"
             },
             "additional_filename": {
-              "type": ["string", "null"],
+              "type": [
+                "string",
+                "null"
+              ],
               "description": "An image file used to add on the mask"
             }
           }
@@ -613,7 +639,11 @@
             "graduation_color": {
               "title": "Rule graduation color",
               "type": "array",
-              "default": [0, 0, 0],
+              "default": [
+                0,
+                0,
+                0
+              ],
               "items": {
                 "type": "integer"
               }
@@ -621,7 +651,11 @@
             "lines_color": {
               "title": "Rule lines color",
               "type": "array",
-              "default": [0, 0, 0],
+              "default": [
+                0,
+                0,
+                0
+              ],
               "items": {
                 "type": "integer"
               }
@@ -644,7 +678,11 @@
             "graduation_text_font_color": {
               "title": "Rule graduation text font color",
               "type": "array",
-              "default": [0, 0, 0],
+              "default": [
+                0,
+                0,
+                0
+              ],
               "items": {
                 "type": "integer"
               }
@@ -678,7 +716,10 @@
               "title": "REST upload API token"
             }
           },
-          "required": ["api_url", "api_token"]
+          "required": [
+            "api_url",
+            "api_token"
+          ]
         },
         "consume_folder": {
           "type": "object",
@@ -690,6 +731,36 @@
               "default": true,
               "description": "Enable using the consume folder",
               "title": "Consume folder enabled"
+            }
+          }
+        },
+        "sam_test": {
+          "type": "object",
+          "title": "SAM test configurations",
+          "description": "Dictionary of SAM test configurations. Each key becomes a directory with green semi-transparent overlay images.",
+          "default": {},
+          "additionalProperties": {
+            "type": "object",
+            "title": "SAM test configuration",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": true,
+                "description": "Enable this SAM test",
+                "title": "SAM test enabled"
+              },
+              "prompt": {
+                "type": "string",
+                "default": "document",
+                "description": "Text prompt for SAM3 segmentation",
+                "title": "SAM test prompt"
+              },
+              "threshold": {
+                "type": "number",
+                "default": 0.5,
+                "description": "Confidence threshold for mask prediction",
+                "title": "SAM test threshold"
+              }
             }
           }
         }
@@ -755,7 +826,10 @@
             "type": "array",
             "title": "The destination image positions",
             "items": {
-              "type": ["integer", "string"]
+              "type": [
+                "integer",
+                "string"
+              ]
             }
           },
           "image": {
@@ -831,7 +905,10 @@
         "additionalProperties": false,
         "properties": {
           "angle": {
-            "type": ["number", "null"],
+            "type": [
+              "number",
+              "null"
+            ],
             "description": "The used angle to deskew, can be change, restart by deleting one of the generated images"
           },
           "status": {
@@ -1015,13 +1092,23 @@
                 "properties": {
                   "angle_from": {
                     "type": "string",
-                    "enum": ["detected", "manual", "none"]
+                    "enum": [
+                      "detected",
+                      "manual",
+                      "none"
+                    ]
                   },
                   "detected_angle": {
-                    "type": ["number", "null"]
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   },
                   "applied_angle": {
-                    "type": ["number", "null"]
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   },
                   "near_search_limit": {
                     "type": "boolean"
@@ -1058,5 +1145,8 @@
       }
     }
   },
-  "required": ["images", "args"]
+  "required": [
+    "images",
+    "args"
+  ]
 }

--- a/scan_to_paperless/process_schema.py
+++ b/scan_to_paperless/process_schema.py
@@ -2,7 +2,7 @@
 # Used to correctly format the generated file
 
 
-from typing import Literal, Required, TypedDict
+from typing import Any, Literal, Required, TypedDict
 
 
 APPEND_CREDIT_CARD_DEFAULT = False
@@ -263,20 +263,21 @@ class Arguments(TypedDict, total=False):
     Upload the final PDF via Paperless REST API
     """
 
-    sam_test: dict[str, "SamTestConfig"]
-    r"""
-    SAM test configurations.
-
-    Dictionary of SAM test configurations. Each key becomes a directory with green semi-transparent overlay images.
-
-    default: {}
-    """
-
     consume_folder: "ConsumeFolder"
     r"""
     Consume folder.
 
     Send the final PDF to Paperless using the consume folder
+    """
+
+    sam_test: dict[str, "SamTestConfiguration"]
+    r"""
+    SAM test configurations.
+
+    Dictionary of SAM test configurations. Each key becomes a directory with green semi-transparent overlay images.
+
+    default:
+      {}
     """
 
 
@@ -478,7 +479,7 @@ r""" Default value of the field path 'Arguments cut_white' """
 
 
 class Configuration(TypedDict, total=False):
-    r"""Configuration."""
+    r""" Configuration. """
 
     images: Required[list[str]]
     r"""
@@ -815,7 +816,7 @@ r""" Default value of the field path 'Auto mask inverse_mask' """
 
 
 class IntermediateError(TypedDict, total=False):
-    r"""Intermediate error."""
+    r""" Intermediate error. """
 
     error: str
     traceback: list[str]
@@ -968,7 +969,7 @@ default: False
 
 
 class Limit(TypedDict, total=False):
-    r"""Limit."""
+    r""" Limit. """
 
     name: str
     r""" The name visible on the generated image """
@@ -1496,6 +1497,26 @@ r""" Default value of the field path 'SAM3 threshold' """
 
 
 
+SAM_TEST_CONFIGURATIONS_DEFAULT: dict[str, Any] = {}
+r""" Default value of the field path 'Arguments sam_test' """
+
+
+
+SAM_TEST_ENABLED_DEFAULT = True
+r""" Default value of the field path 'SAM test configuration enabled' """
+
+
+
+SAM_TEST_PROMPT_DEFAULT = 'document'
+r""" Default value of the field path 'SAM test configuration prompt' """
+
+
+
+SAM_TEST_THRESHOLD_DEFAULT = 0.5
+r""" Default value of the field path 'SAM test configuration threshold' """
+
+
+
 SHARPEN_DEFAULT = {'enabled': False}
 r""" Default value of the field path 'Arguments sharpen' """
 
@@ -1542,17 +1563,8 @@ class Sam3(TypedDict, total=False):
 
 
 
-SAM_TEST_CONFIG_DEFAULT: dict[str, "SamTestConfig"] = {}
-r""" Default value of the field path 'Arguments sam_test' """
-
-
-
-class SamTestConfig(TypedDict, total=False):
-    r"""
-    SAM test configuration.
-
-    A single SAM test entry in the sam_test dictionary.
-    """
+class SamTestConfiguration(TypedDict, total=False):
+    r""" SAM test configuration. """
 
     enabled: bool
     r"""
@@ -1605,7 +1617,7 @@ class Sharpen(TypedDict, total=False):
 
 
 class Step(TypedDict, total=False):
-    r"""Step."""
+    r""" Step. """
 
     name: str
     r""" The step name """
@@ -1671,7 +1683,7 @@ r""" Default value of the field path 'Auto mask upper_hsv_color' """
 
 
 class _ArgumentsDeskew(TypedDict, total=False):
-    r"""The deskew configuration"""
+    r""" The deskew configuration """
 
     min_angle: int | float
     r"""
@@ -1755,7 +1767,7 @@ class _ConfigurationImagesConfigAdditionalpropertiesStatus(TypedDict, total=Fals
 
 
 class _ConfigurationImagesConfigAdditionalpropertiesStatusAutoMaskHsv(TypedDict, total=False):
-    r"""HSV analysis and suggested ranges for auto_mask lower_hsv_color and upper_hsv_color"""
+    r""" HSV analysis and suggested ranges for auto_mask lower_hsv_color and upper_hsv_color """
 
     white_candidate_ratio: int | float
     suggestions: "_ConfigurationImagesConfigAdditionalpropertiesStatusAutoMaskHsvSuggestions"
@@ -1782,7 +1794,7 @@ class _ConfigurationImagesConfigAdditionalpropertiesStatusAutoMaskHsvSuggestions
 
 
 class _ConfigurationImagesConfigAdditionalpropertiesStatusDeskew(TypedDict, total=False):
-    r"""Deskew analysis with detected/applied angle and search configuration"""
+    r""" Deskew analysis with detected/applied angle and search configuration """
 
     angle_from: "_ConfigurationImagesConfigAdditionalpropertiesStatusDeskewAngleFrom"
     detected_angle: int | float | None
@@ -1791,7 +1803,7 @@ class _ConfigurationImagesConfigAdditionalpropertiesStatusDeskew(TypedDict, tota
     search: "_ConfigurationImagesConfigAdditionalpropertiesStatusDeskewSearch"
 
 
-_ConfigurationImagesConfigAdditionalpropertiesStatusDeskewAngleFrom = Literal['detected', 'manual', 'none']
+_ConfigurationImagesConfigAdditionalpropertiesStatusDeskewAngleFrom = Literal['detected'] | Literal['manual'] | Literal['none']
 _CONFIGURATIONIMAGESCONFIGADDITIONALPROPERTIESSTATUSDESKEWANGLEFROM_DETECTED: Literal['detected'] = "detected"
 r"""The values for the '_ConfigurationImagesConfigAdditionalpropertiesStatusDeskewAngleFrom' enum"""
 _CONFIGURATIONIMAGESCONFIGADDITIONALPROPERTIESSTATUSDESKEWANGLEFROM_MANUAL: Literal['manual'] = "manual"
@@ -1811,7 +1823,7 @@ class _ConfigurationImagesConfigAdditionalpropertiesStatusDeskewSearch(TypedDict
 
 
 class _ConfigurationImagesConfigAdditionalpropertiesStatusHistogram(TypedDict, total=False):
-    r"""Information based on the image histogram to help tune cut_black/cut_white"""
+    r""" Information based on the image histogram to help tune cut_black/cut_white """
 
     text: list[str]
     r""" Textual histogram lines """

--- a/scan_to_paperless/process_schema.py
+++ b/scan_to_paperless/process_schema.py
@@ -263,6 +263,15 @@ class Arguments(TypedDict, total=False):
     Upload the final PDF via Paperless REST API
     """
 
+    sam_test: dict[str, "SamTestConfig"]
+    r"""
+    SAM test configurations.
+
+    Dictionary of SAM test configurations. Each key becomes a directory with green semi-transparent overlay images.
+
+    default: {}
+    """
+
     consume_folder: "ConsumeFolder"
     r"""
     Consume folder.
@@ -469,7 +478,7 @@ r""" Default value of the field path 'Arguments cut_white' """
 
 
 class Configuration(TypedDict, total=False):
-    r""" Configuration. """
+    r"""Configuration."""
 
     images: Required[list[str]]
     r"""
@@ -806,7 +815,7 @@ r""" Default value of the field path 'Auto mask inverse_mask' """
 
 
 class IntermediateError(TypedDict, total=False):
-    r""" Intermediate error. """
+    r"""Intermediate error."""
 
     error: str
     traceback: list[str]
@@ -959,7 +968,7 @@ default: False
 
 
 class Limit(TypedDict, total=False):
-    r""" Limit. """
+    r"""Limit."""
 
     name: str
     r""" The name visible on the generated image """
@@ -1533,6 +1542,47 @@ class Sam3(TypedDict, total=False):
 
 
 
+SAM_TEST_CONFIG_DEFAULT: dict[str, "SamTestConfig"] = {}
+r""" Default value of the field path 'Arguments sam_test' """
+
+
+
+class SamTestConfig(TypedDict, total=False):
+    r"""
+    SAM test configuration.
+
+    A single SAM test entry in the sam_test dictionary.
+    """
+
+    enabled: bool
+    r"""
+    SAM test enabled.
+
+    Enable this SAM test
+
+    default: True
+    """
+
+    prompt: str
+    r"""
+    SAM test prompt.
+
+    Text prompt for SAM3 segmentation
+
+    default: document
+    """
+
+    threshold: int | float
+    r"""
+    SAM test threshold.
+
+    Confidence threshold for mask prediction
+
+    default: 0.5
+    """
+
+
+
 class Sharpen(TypedDict, total=False):
     r"""
     Sharpen.
@@ -1555,7 +1605,7 @@ class Sharpen(TypedDict, total=False):
 
 
 class Step(TypedDict, total=False):
-    r""" Step. """
+    r"""Step."""
 
     name: str
     r""" The step name """
@@ -1621,7 +1671,7 @@ r""" Default value of the field path 'Auto mask upper_hsv_color' """
 
 
 class _ArgumentsDeskew(TypedDict, total=False):
-    r""" The deskew configuration """
+    r"""The deskew configuration"""
 
     min_angle: int | float
     r"""
@@ -1705,7 +1755,7 @@ class _ConfigurationImagesConfigAdditionalpropertiesStatus(TypedDict, total=Fals
 
 
 class _ConfigurationImagesConfigAdditionalpropertiesStatusAutoMaskHsv(TypedDict, total=False):
-    r""" HSV analysis and suggested ranges for auto_mask lower_hsv_color and upper_hsv_color """
+    r"""HSV analysis and suggested ranges for auto_mask lower_hsv_color and upper_hsv_color"""
 
     white_candidate_ratio: int | float
     suggestions: "_ConfigurationImagesConfigAdditionalpropertiesStatusAutoMaskHsvSuggestions"
@@ -1732,7 +1782,7 @@ class _ConfigurationImagesConfigAdditionalpropertiesStatusAutoMaskHsvSuggestions
 
 
 class _ConfigurationImagesConfigAdditionalpropertiesStatusDeskew(TypedDict, total=False):
-    r""" Deskew analysis with detected/applied angle and search configuration """
+    r"""Deskew analysis with detected/applied angle and search configuration"""
 
     angle_from: "_ConfigurationImagesConfigAdditionalpropertiesStatusDeskewAngleFrom"
     detected_angle: int | float | None
@@ -1741,7 +1791,7 @@ class _ConfigurationImagesConfigAdditionalpropertiesStatusDeskew(TypedDict, tota
     search: "_ConfigurationImagesConfigAdditionalpropertiesStatusDeskewSearch"
 
 
-_ConfigurationImagesConfigAdditionalpropertiesStatusDeskewAngleFrom = Literal['detected'] | Literal['manual'] | Literal['none']
+_ConfigurationImagesConfigAdditionalpropertiesStatusDeskewAngleFrom = Literal['detected', 'manual', 'none']
 _CONFIGURATIONIMAGESCONFIGADDITIONALPROPERTIESSTATUSDESKEWANGLEFROM_DETECTED: Literal['detected'] = "detected"
 r"""The values for the '_ConfigurationImagesConfigAdditionalpropertiesStatusDeskewAngleFrom' enum"""
 _CONFIGURATIONIMAGESCONFIGADDITIONALPROPERTIESSTATUSDESKEWANGLEFROM_MANUAL: Literal['manual'] = "manual"
@@ -1761,7 +1811,7 @@ class _ConfigurationImagesConfigAdditionalpropertiesStatusDeskewSearch(TypedDict
 
 
 class _ConfigurationImagesConfigAdditionalpropertiesStatusHistogram(TypedDict, total=False):
-    r""" Information based on the image histogram to help tune cut_black/cut_white """
+    r"""Information based on the image histogram to help tune cut_black/cut_white"""
 
     text: list[str]
     r""" Textual histogram lines """

--- a/scan_to_paperless/process_utils.py
+++ b/scan_to_paperless/process_utils.py
@@ -56,7 +56,7 @@ def _load_model_and_processor() -> tuple[Sam3Model, Sam3Processor, str]:
     return _MODEL, _PROCESSOR, _DEVICE
 
 
-def _run_sam3_inference(
+def run_sam3_inference(
     image: "Image.Image",
     text_prompt: str,
     threshold: float,
@@ -200,7 +200,7 @@ class Context:
                 image_rgb = cv2.cvtColor(self.image, cv2.COLOR_BGR2RGB)
 
                 mask = await anyio.to_thread.run_sync(
-                    _run_sam3_inference,
+                    run_sam3_inference,
                     Image.fromarray(image_rgb, mode="RGB"),
                     sam3_config.get("prompt", schema.SAM3_PROMPT_DEFAULT),
                     sam3_config.get("threshold", schema.SAM3_THRESHOLD_DEFAULT),

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -7,6 +7,7 @@ from typing import Any
 import anyio
 import cv2
 import nbformat
+import numpy as np
 import pikepdf
 import pytest
 import skimage.color
@@ -14,6 +15,7 @@ import skimage.io
 from anyio import Path
 from c2cwsgiutils.acceptance.image import check_image, check_image_file
 from nbconvert.preprocessors import ExecutePreprocessor
+from PIL import Image
 
 from scan_to_paperless import add_code, process, process_utils
 
@@ -1145,3 +1147,74 @@ async def test_external_decorator_valid_output() -> None:
     assert result is not None
     assert isinstance(result, type(context.image))  # Should be same type as input (numpy array)
     assert result.shape == context.image.shape  # Should have same dimensions
+
+
+# @pytest.mark.skip(reason="for test")
+@pytest.mark.asyncio
+async def test_draw_mask_overlay() -> None:
+    """Test the draw_mask_overlay function."""
+    image = np.zeros((100, 100, 3), dtype=np.uint8)
+    image[:, :] = [255, 255, 255]
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    mask[25:75, 25:75] = 255
+
+    overlay = process.draw_mask_overlay(image, mask)
+
+    assert overlay.shape == image.shape
+    assert overlay.dtype == image.dtype
+
+    # Pixel inside mask should differ from original due to green overlay
+    assert not np.array_equal(overlay[50, 50], image[50, 50])
+    # Pixel outside mask should remain unchanged
+    assert np.array_equal(overlay[0, 0], image[0, 0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("test_name", "test_config"),
+    [
+        pytest.param("page", {"prompt": "document"}, id="page"),
+        pytest.param("ticket", {"prompt": "receipt", "threshold": 0.3}, id="ticket"),
+    ],
+)
+async def test_sam_test(test_name: str, test_config: dict[str, Any]) -> None:
+    """Test SAM test configuration execution."""
+    pytest.importorskip("transformers")
+    init_test()
+    context = process_utils.Context(
+        {"args": {"sam_test": {test_name: test_config}}},
+        {},
+    )
+    context.image = cv2.imread(str(Path(__file__).parent / "sam-page.png"))
+    assert context.image is not None
+    context.image_name = "sam-page.png"
+    root_folder = Path("/tmp/sam-test-output")  # noqa: S108
+    if await root_folder.exists():
+        shutil.rmtree(str(root_folder))
+
+    sam_test_configs = context.config["args"].get("sam_test", {})
+    for sam_test_name, sam_test_cfg in sam_test_configs.items():
+        if not sam_test_cfg.get("enabled", True):
+            continue
+        image_rgb = cv2.cvtColor(context.image, cv2.COLOR_BGR2RGB)
+        mask = await anyio.to_thread.run_sync(
+            process_utils.run_sam3_inference,
+            Image.fromarray(image_rgb, mode="RGB"),
+            sam_test_cfg.get("prompt", "document"),
+            sam_test_cfg.get("threshold", 0.5),
+        )
+        overlay = process.draw_mask_overlay(context.image, mask)
+
+        dest_folder = root_folder / sam_test_name
+        await dest_folder.mkdir(parents=True)
+        success, buffer = cv2.imencode(".png", overlay)
+        assert success
+        file_path = dest_folder / context.image_name
+        async with await anyio.open_file(str(file_path), "wb") as f:
+            await f.write(buffer.tobytes())
+
+        assert await file_path.exists()
+        # Check alpha channel is not present (BGR image)
+        assert overlay.shape[2] == 3
+
+    shutil.rmtree(str(root_folder))


### PR DESCRIPTION
**Summary**
Add a new `args.sam_test` dictionary that allows defining arbitrary SAM3 test configurations. Each key becomes a subfolder in the job directory containing the processed image with a green semi-transparent overlay (same style as crop rectangles) showing the detected mask.

**Context**
- This feature helps users evaluate SAM3 mask quality for different prompts and thresholds without modifying the main processing pipeline
- Related to SAM3 mask generation improvements

**Implementation Details**
- `args.sam_test` is a free-form dictionary (additionalProperties) where each key is a test name and each value is a SAM3 config (enabled, prompt, threshold)
- Each test runs SAM3 inference independently with its own prompt/threshold
- The overlay uses the same green color `(0, 255, 0)` and opacity `0.1` as the crop rectangle overlay
- Runs in `transform()` right after `init_mask()` to use the current image state
- The `_run_sam3_inference` function was renamed to `run_sam3_inference` (made public) to be accessible from `process.py`
- Jupyter notebook includes a new cell to display SAM test overlays

**Testing & Validation**
- `test_draw_mask_overlay` — verifies the overlay function produces correct pixel values (no model required)
- `test_sam_test` — parametrized test with page and ticket configs, runs SAM3 inference and verifies output files (requires transformers)
- Syntax verified with ruff and py_compile