### PR TITLE
Add SAM3 cache for inference results

### DIFF
--- a/scan_to_paperless/jupyter.py
+++ b/scan_to_paperless/jupyter.py
@@ -351,20 +351,42 @@ context.config["args"]["sam_test"] = {_pretty_repr(context.config["args"].get("s
 
 sam_test_configs = context.config["args"].get("sam_test", {{}})
 if sam_test_configs:
-    from scan_to_paperless.process_utils import run_sam3_inference
+    from scan_to_paperless.process_utils import load_sam3_cache, save_sam3_cache, run_sam3_inference
 
     for test_name, test_config in sam_test_configs.items():
         if not test_config.get("enabled", True):
             continue
         print(f"Running SAM test: {{test_name}}")
-        image_rgb = cv2.cvtColor(context.image, cv2.COLOR_BGR2RGB)
-        mask = await anyio.to_thread.run_sync(
-            run_sam3_inference,
-            Image.fromarray(image_rgb, mode="RGB"),
-            test_config.get("prompt", "document"),
-            test_config.get("threshold", 0.5),
-            test_config.get("scale", 4),
+        prompt = test_config.get("prompt", "document")
+        threshold = test_config.get("threshold", 0.5)
+        scale = test_config.get("scale", 4)
+
+        cached_mask = await load_sam3_cache(
+            context.root_folder,
+            context.image_name,
+            prompt,
+            scale,
+            threshold,
         )
+        if cached_mask is not None:
+            mask = cached_mask
+        else:
+            image_rgb = cv2.cvtColor(context.image, cv2.COLOR_BGR2RGB)
+            mask = await anyio.to_thread.run_sync(
+                run_sam3_inference,
+                Image.fromarray(image_rgb, mode="RGB"),
+                prompt,
+                threshold,
+                scale,
+            )
+            await save_sam3_cache(
+                context.root_folder,
+                context.image_name,
+                prompt,
+                scale,
+                threshold,
+                mask,
+            )
         overlay = process.draw_mask_overlay(context.image, mask)
         context.display_image(overlay)
 else:

--- a/scan_to_paperless/process.py
+++ b/scan_to_paperless/process.py
@@ -1556,14 +1556,36 @@ async def transform(
             for test_name, test_config in sam_test_configs.items():
                 if not test_config.setdefault("enabled", True):
                     continue
-                image_rgb = cv2.cvtColor(context.image, cv2.COLOR_BGR2RGB)
-                mask = await anyio.to_thread.run_sync(
-                    process_utils.run_sam3_inference,
-                    Image.fromarray(image_rgb, mode="RGB"),
-                    test_config.setdefault("prompt", schema.SAM3_PROMPT_DEFAULT),
-                    test_config.setdefault("threshold", schema.SAM3_THRESHOLD_DEFAULT),
-                    test_config.setdefault("scale", schema.SAM3_SCALE_DEFAULT),
+                prompt = test_config.setdefault("prompt", schema.SAM3_PROMPT_DEFAULT)
+                threshold = test_config.setdefault("threshold", schema.SAM3_THRESHOLD_DEFAULT)
+                scale = test_config.setdefault("scale", schema.SAM3_SCALE_DEFAULT)
+
+                cached_mask = await process_utils.load_sam3_cache(
+                    context.root_folder,
+                    context.image_name,
+                    prompt,
+                    scale,
+                    threshold,
                 )
+                if cached_mask is not None:
+                    mask = cached_mask
+                else:
+                    image_rgb = cv2.cvtColor(context.image, cv2.COLOR_BGR2RGB)
+                    mask = await anyio.to_thread.run_sync(
+                        process_utils.run_sam3_inference,
+                        Image.fromarray(image_rgb, mode="RGB"),
+                        prompt,
+                        threshold,
+                        scale,
+                    )
+                    await process_utils.save_sam3_cache(
+                        context.root_folder,
+                        context.image_name,
+                        prompt,
+                        scale,
+                        threshold,
+                        mask,
+                    )
                 overlay = draw_mask_overlay(context.image, mask)
                 dest_folder = root_folder / test_name
                 if not await dest_folder.exists():

--- a/scan_to_paperless/process_utils.py
+++ b/scan_to_paperless/process_utils.py
@@ -1,5 +1,6 @@
 """Utility functions and context used in the process."""
 
+import io
 import logging
 import math
 import os
@@ -11,6 +12,7 @@ import numpy as np
 import torch
 from anyio import Path
 from PIL import Image
+from ruamel.yaml.main import YAML
 from transformers import Sam3Model, Sam3Processor
 
 import scan_to_paperless
@@ -30,6 +32,8 @@ _LOG = logging.getLogger(__name__)
 _MODEL: Sam3Model | None = None
 _PROCESSOR: Sam3Processor | None = None
 _DEVICE: str | None = None
+
+_SAM3_CACHE_DIR = "sam3"
 
 
 def _load_model_and_processor() -> tuple[Sam3Model, Sam3Processor, str]:
@@ -54,6 +58,73 @@ def _load_model_and_processor() -> tuple[Sam3Model, Sam3Processor, str]:
         revision="main",
     )  # nosec
     return _MODEL, _PROCESSOR, _DEVICE
+
+
+async def save_sam3_cache(
+    root_folder: Path | None,
+    image_name: str | None,
+    prompt: str,
+    scale: float,
+    threshold: float,
+    mask: np.ndarray,
+) -> None:
+    """Save SAM3 inference result to cache."""
+    if root_folder is None or image_name is None:
+        return
+    cache_dir = root_folder / _SAM3_CACHE_DIR
+    if not await cache_dir.exists():
+        await cache_dir.mkdir(parents=True)
+
+    mask_path = cache_dir / image_name
+    success, buffer = cv2.imencode(".png", mask)
+    if success:
+        async with await anyio.open_file(str(mask_path), "wb") as file:
+            await file.write(buffer.tobytes())
+
+    yaml_path = cache_dir / f"{image_name}.yaml"
+    meta = {"prompt": prompt, "scale": scale, "threshold": threshold}
+    yaml = YAML()
+    yaml.default_flow_style = False
+    string_buffer = io.StringIO()
+    yaml.dump(meta, string_buffer)
+    async with await anyio.open_file(str(yaml_path), "w", encoding="utf-8") as file:
+        await file.write(string_buffer.getvalue())
+
+
+async def load_sam3_cache(
+    root_folder: Path | None,
+    image_name: str | None,
+    prompt: str,
+    scale: float,
+    threshold: float,
+) -> np.ndarray | None:
+    """Load SAM3 inference result from cache if parameters match."""
+    if root_folder is None or image_name is None:
+        return None
+    cache_dir = root_folder / _SAM3_CACHE_DIR
+    mask_path = cache_dir / image_name
+    yaml_path = cache_dir / f"{image_name}.yaml"
+
+    if not await mask_path.exists() or not await yaml_path.exists():
+        return None
+
+    async with await anyio.open_file(str(yaml_path), "r", encoding="utf-8") as file:
+        content = await file.read()
+    yaml = YAML(typ="safe")
+    meta = yaml.load(content)
+
+    if meta.get("prompt") != prompt or meta.get("scale") != scale or meta.get("threshold") != threshold:
+        return None
+
+    async with await anyio.open_file(str(mask_path), "rb") as file:
+        mask_bytes = await file.read()
+    mask_array = np.frombuffer(mask_bytes, dtype=np.uint8)
+    mask = cv2.imdecode(mask_array, cv2.IMREAD_GRAYSCALE)
+    if mask is None:
+        return None
+
+    print(f"Use SAM3 cache for {image_name}")
+    return mask
 
 
 def run_sam3_inference(
@@ -216,15 +287,37 @@ class Context:
 
             sam3_config: schema.Sam3 = auto_mask_config.setdefault("sam3", {})
             if sam3_config.setdefault("enabled", schema.SAM3_ENABLED_DEFAULT):
-                image_rgb = cv2.cvtColor(self.image, cv2.COLOR_BGR2RGB)
+                prompt = sam3_config.setdefault("prompt", schema.SAM3_PROMPT_DEFAULT)
+                threshold = sam3_config.setdefault("threshold", schema.SAM3_THRESHOLD_DEFAULT)
+                scale = sam3_config.setdefault("scale", schema.SAM3_SCALE_DEFAULT)
 
-                mask = await anyio.to_thread.run_sync(
-                    run_sam3_inference,
-                    Image.fromarray(image_rgb, mode="RGB"),
-                    sam3_config.setdefault("prompt", schema.SAM3_PROMPT_DEFAULT),
-                    sam3_config.setdefault("threshold", schema.SAM3_THRESHOLD_DEFAULT),
-                    sam3_config.setdefault("scale", schema.SAM3_SCALE_DEFAULT),
+                cached_mask = await load_sam3_cache(
+                    self.root_folder,
+                    self.image_name,
+                    prompt,
+                    scale,
+                    threshold,
                 )
+                if cached_mask is not None:
+                    mask = cached_mask
+                else:
+                    image_rgb = cv2.cvtColor(self.image, cv2.COLOR_BGR2RGB)
+
+                    mask = await anyio.to_thread.run_sync(
+                        run_sam3_inference,
+                        Image.fromarray(image_rgb, mode="RGB"),
+                        prompt,
+                        threshold,
+                        scale,
+                    )
+                    await save_sam3_cache(
+                        self.root_folder,
+                        self.image_name,
+                        prompt,
+                        scale,
+                        threshold,
+                        mask,
+                    )
 
                 inverse_mask = auto_mask_config.setdefault("inverse_mask", schema.INVERSE_MASK_DEFAULT)
                 if inverse_mask:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1178,31 +1178,68 @@ async def test_draw_mask_overlay() -> None:
     ],
 )
 async def test_sam_test(test_name: str, test_config: dict[str, Any]) -> None:
-    """Test SAM test configuration execution."""
+    """Test SAM test configuration execution with cache."""
     pytest.importorskip("transformers")
     init_test()
+    root_folder = Path("/tmp/sam-test-output")  # noqa: S108
+    if await root_folder.exists():
+        shutil.rmtree(str(root_folder))
+
     context = process_utils.Context(
         {"args": {"sam_test": {test_name: test_config}}},
         {},
+        root_folder=root_folder,
     )
     context.image = cv2.imread(str(Path(__file__).parent / "sam-page.png"))
     assert context.image is not None
     context.image_name = "sam-page.png"
-    root_folder = Path("/tmp/sam-test-output")  # noqa: S108
-    if await root_folder.exists():
-        shutil.rmtree(str(root_folder))
 
     sam_test_configs = context.config["args"].get("sam_test", {})
     for sam_test_name, sam_test_cfg in sam_test_configs.items():
         if not sam_test_cfg.get("enabled", True):
             continue
+        prompt = sam_test_cfg.get("prompt", "document")
+        threshold = sam_test_cfg.get("threshold", 0.5)
+        scale = sam_test_cfg.get("scale", 4)
+
+        # First run: run inference and save to cache
         image_rgb = cv2.cvtColor(context.image, cv2.COLOR_BGR2RGB)
         mask = await anyio.to_thread.run_sync(
             process_utils.run_sam3_inference,
             Image.fromarray(image_rgb, mode="RGB"),
-            sam_test_cfg.get("prompt", "document"),
-            sam_test_cfg.get("threshold", 0.5),
+            prompt,
+            threshold,
+            scale,
         )
+
+        await process_utils.save_sam3_cache(
+            root_folder,
+            context.image_name,
+            prompt,
+            scale,
+            threshold,
+            mask,
+        )
+
+        # Verify cache files exist
+        cache_dir = root_folder / "sam3"
+        mask_path = cache_dir / context.image_name
+        yaml_path = cache_dir / f"{context.image_name}.yaml"
+        assert await mask_path.exists()
+        assert await yaml_path.exists()
+
+        # Verify can load from cache
+        loaded_mask = await process_utils.load_sam3_cache(
+            root_folder,
+            context.image_name,
+            prompt,
+            scale,
+            threshold,
+        )
+        assert loaded_mask is not None
+        assert np.array_equal(mask, loaded_mask)
+
+        # Generate and save overlay (original behavior)
         overlay = process.draw_mask_overlay(context.image, mask)
 
         dest_folder = root_folder / sam_test_name
@@ -1216,5 +1253,35 @@ async def test_sam_test(test_name: str, test_config: dict[str, Any]) -> None:
         assert await file_path.exists()
         # Check alpha channel is not present (BGR image)
         assert overlay.shape[2] == 3
+
+        # Verify cache miss with different params
+        different_cache = await process_utils.load_sam3_cache(
+            root_folder,
+            context.image_name,
+            "different_prompt",
+            scale,
+            threshold,
+        )
+        assert different_cache is None
+
+        # Verify cache miss with different scale
+        different_scale = await process_utils.load_sam3_cache(
+            root_folder,
+            context.image_name,
+            prompt,
+            2.0,
+            threshold,
+        )
+        assert different_scale is None
+
+        # Verify cache miss with different threshold
+        different_threshold = await process_utils.load_sam3_cache(
+            root_folder,
+            context.image_name,
+            prompt,
+            scale,
+            0.9,
+        )
+        assert different_threshold is None
 
     shutil.rmtree(str(root_folder))


### PR DESCRIPTION
## Summary

Add on-disk caching for SAM3 inference results to avoid re-running expensive inference on reruns.

## Context

SAM3 inference is expensive (several seconds per image even on GPU). On each pipeline rerun the inference was re-executed even when the image and configuration parameters were identical.

## Implementation Details

The cache stores raw SAM3 masks in a `sam3/` subdirectory under the job root folder:
- `root_folder/sam3/<image_name>.png` - the binary mask
- `root_folder/sam3/<image_name>.yaml` - metadata (prompt, scale, threshold)

Before running inference, the metadata file is read and compared against the requested parameters. If they match, the cached mask is loaded instead of re-running inference.

The cache is shared between both SAM3 usage contexts:
- Auto-masking via `_get_mask()` in `process_utils.py`
- SAM test overlays in `transform()` in `process.py` and the Jupyter notebook

## Testing \& Validation

The existing `test_sam_test` test was extended to verify:
- Cache files (.png and .yaml) are created after inference
- Loading from cache returns the same mask
- Cache misses correctly when prompt, scale, or threshold differ