### PR TITLE
Fix SAM3 cache YAML filename to remove image extension

### DIFF
--- a/scan_to_paperless/process_utils.py
+++ b/scan_to_paperless/process_utils.py
@@ -81,7 +81,7 @@ async def save_sam3_cache(
         async with await anyio.open_file(str(mask_path), "wb") as file:
             await file.write(buffer.tobytes())
 
-    yaml_path = cache_dir / f"{image_name}.yaml"
+    yaml_path = cache_dir / f"{Path(image_name).stem}.yaml"
     meta = {"prompt": prompt, "scale": scale, "threshold": threshold}
     yaml = YAML()
     yaml.default_flow_style = False
@@ -103,7 +103,7 @@ async def load_sam3_cache(
         return None
     cache_dir = root_folder / _SAM3_CACHE_DIR
     mask_path = cache_dir / image_name
-    yaml_path = cache_dir / f"{image_name}.yaml"
+    yaml_path = cache_dir / f"{Path(image_name).stem}.yaml"
 
     if not await mask_path.exists() or not await yaml_path.exists():
         return None

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1224,7 +1224,7 @@ async def test_sam_test(test_name: str, test_config: dict[str, Any]) -> None:
         # Verify cache files exist
         cache_dir = root_folder / "sam3"
         mask_path = cache_dir / context.image_name
-        yaml_path = cache_dir / f"{context.image_name}.yaml"
+        yaml_path = cache_dir / f"{Path(context.image_name).stem}.yaml"
         assert await mask_path.exists()
         assert await yaml_path.exists()
 


### PR DESCRIPTION
## Summary

Fix the SAM3 cache YAML file naming: when `image_name` is `image-1.png`, the cache YAML was named `image-1.png.yaml` instead of `image-1.yaml`.

## Implementation Details

Used `Path(image_name).stem` to strip the image extension before appending `.yaml`.

## Impact/Risks

Low risk. This changes the cache filename format, so existing caches will be invalidated and regenerated.