### PR TITLE
Pin ruff and pylint in the project

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6110,4 +6110,4 @@ sane = ["python-sane"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,!=3.14.1,<3.15"
-content-hash = "316ebe40c386f919ad8c0b06f279866ab5d3c550ea529611b010a75761157f68"
+content-hash = "dc6579e0649c8c78311d9b2f8a6d6364bb4a5004a35849df021a7a93a3c910bc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ c2cwsgiutils = { version = "6.1.10", extras = ["test_images"] }
 types-requests = "2.33.0.20260712"
 nbconvert = "7.17.1"
 ipykernel = "7.3.0"
+ruff = "0.16.1"
+pylint = "4.0.6"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Prospector uses ruff and pylint, they should be pinned alongside prospector.